### PR TITLE
feat: Purge CF Image and Thumbs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,8 @@
 			"phpcs -p -s",
 			"minus-x check ."
 		]
+	},
+	"extra": {
+		"installer-name": "CloudFlare"
 	}
 }

--- a/extension.json
+++ b/extension.json
@@ -12,7 +12,10 @@
 	"namemsg": "cloudflare",
 	"descriptionmsg": "cloudflare-desc",
 	"requires": {
-		"MediaWiki": ">= 1.35.0"
+		"MediaWiki": ">= 1.35.0",
+		"platform": {
+			"ext-curl": "*"
+		}
 	},
 	"MessagesDirs": {
 		"CloudFlare": [
@@ -24,7 +27,8 @@
 	},
 	"Hooks": {
 		"LocalFilePurgeThumbnails": "purge",
-		"TitleSquidURLs": "purge"
+		"TitleSquidURLs": "purge",
+		"ArticlePurge": "purge"
 	},
 	"HookHandlers": {
 		"purge": {

--- a/includes/Hooks/HookUtils.php
+++ b/includes/Hooks/HookUtils.php
@@ -27,15 +27,15 @@ class HookUtils {
 		$accountId = $config->get( 'CloudFlareAccountId' );
 
 		// Return if any info is missing
-		if ( empty( $zoneId ) || empty( $apiToken ) || empty( $accountId ) ) {
+		if ( empty( $zoneId ) || empty( $apiToken ) || empty( $accountId ) || empty( $urls ) ) {
 			return;
 		}
 
 		$fac = MediaWikiServices::getInstance()->getHttpRequestFactory();
 		$req = $fac->create( sprintf( 'https://api.cloudflare.com/client/v4/zones/%s/purge_cache', $zoneId ) );
-		$req->setHeader( 'X-Auth-Key', $accountId );
-		$req->setHeader( 'Authorization', sprintf( 'Bearer %s', $apiToken ) );
-		$req->setHeader( 'Content-Type', 'application/json' );
+		$req->setHeader( strtolower( 'X-Auth-Key' ), $accountId );
+		$req->setHeader( strtolower( 'Authorization' ), sprintf( 'Bearer %s', $apiToken ) );
+		$req->setHeader( strtolower( 'Content-Type' ), 'application/json' );
 
 		$req->setData( [
 			'files' => $urls

--- a/includes/Hooks/PurgeHooks.php
+++ b/includes/Hooks/PurgeHooks.php
@@ -11,12 +11,19 @@ declare( strict_types=1 );
 
 namespace MediaWiki\Extension\CloudFlare\Hooks;
 
+use Article;
 use File;
 use MediaWiki\Hook\LocalFilePurgeThumbnailsHook;
 use MediaWiki\Hook\TitleSquidURLsHook;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Page\Hook\ArticlePurgeHook;
+use ReflectionException;
+use ReflectionObject;
 use Title;
+use WikiFilePage;
+use WikiPage;
 
-class PurgeHooks implements	LocalFilePurgeThumbnailsHook, TitleSquidURLsHook {
+class PurgeHooks implements	LocalFilePurgeThumbnailsHook, TitleSquidURLsHook, ArticlePurgeHook {
 
 	/**
 	 * Retrieve a list of thumbnail URLs that needs to be purged
@@ -27,7 +34,11 @@ class PurgeHooks implements	LocalFilePurgeThumbnailsHook, TitleSquidURLsHook {
 	 * @param string $archiveName Name of an old file version or false if it's the current one
 	 */
 	public function onLocalFilePurgeThumbnails( $file, $archiveName ): void {
-		( new HookUtils() )->purgeUrls( [ $file->getThumbUrl() ] );
+		$files = $this->getThumbnails( $file );
+		// Remove mwbackend link
+		array_shift( $files );
+
+		$this->runPurge( $this->linkThumbnails( $files, $file ) );
 	}
 
 	/**
@@ -39,8 +50,135 @@ class PurgeHooks implements	LocalFilePurgeThumbnailsHook, TitleSquidURLsHook {
 	 * @param string[] &$urls Array of URLs to purge from the caches, to be manipulated
 	 */
 	public function onTitleSquidURLs( $title, &$urls ): void {
-		if ( $urls ) {
-			( new HookUtils() )->purgeUrls( $urls );
+		if ( !$this->isValid( $title ) ) {
+			return;
 		}
+
+		if ( !empty( $urls ) ) {
+			$this->runPurge( $urls );
+		}
+	}
+
+	/**
+	 * @param WikiPage $wikiPage
+	 * @return void
+	 */
+	public function onArticlePurge( $wikiPage ): void {
+		if ( !$this->isValid( $wikiPage ) ) {
+			return;
+		}
+
+		$files = $this->getThumbnails( $wikiPage->getFile() );
+		// Remove mwbackend link
+		array_shift( $files );
+
+		$this->runPurge( $this->linkThumbnails( $files, $wikiPage->getFile() ) );
+	}
+
+	/**
+	 * Returns an array of thumbnail urls for this wiki file
+	 * This is an evil hack if you are on <= 1.35.2 as we change the visibility of the method to public
+	 *
+	 * @param File|WikiFilePage $page
+	 * @return array
+	 */
+	private function getThumbnails( $page ): array {
+		if ( $page instanceof File ) {
+			$file = $page;
+		} else {
+			$file = $page->getFile();
+		}
+
+		if ( $file === false || !method_exists( $file, 'getThumbnails' ) ) {
+			return [];
+		}
+
+		$refObject = new ReflectionObject( $file );
+		try {
+			$refMethod = $refObject->getMethod( 'getThumbnails' );
+		} catch ( ReflectionException $e ) {
+			return [];
+		}
+
+		if ( $refMethod->isPublic() ) {
+			return $file->getThumbnails();
+		}
+
+		try {
+			$refMethod->setAccessible( true );
+			$thumbnails = $refMethod->invoke( $file );
+		} catch ( ReflectionException $e ) {
+			$thumbnails = [];
+		}
+
+		return $thumbnails;
+	}
+
+	/**
+	 * Links relative urls to absolute urls based on wgServer or wgUploadPath
+	 *
+	 * @param array $files
+	 * @param File $baseFile
+	 * @return array
+	 */
+	private function linkThumbnails( array $files, File $baseFile ): array {
+		$url = MediaWikiServices::getInstance()->getMainConfig()->get( 'Server' );
+		$uploadPath = MediaWikiServices::getInstance()->getMainConfig()->get( 'UploadPath' );
+		$parsed = parse_url( $uploadPath );
+
+		if ( $parsed !== false && isset( $parsed['host'] ) ) {
+			$url = $uploadPath;
+		}
+
+		// Purge the CDN
+		$urls = [];
+		foreach ( $files as $thumb ) {
+			$thumbUrl = ltrim( $baseFile->getThumbUrl( $thumb ), '/' );
+			if ( isset( parse_url( $thumbUrl )['host'] ) ) {
+				$urls[] = $thumbUrl;
+			} else {
+				$urls[] = sprintf(
+					'%s/%s',
+					$url,
+					ltrim( $baseFile->getThumbUrl( $thumb ), '/' )
+				);
+			}
+
+		}
+
+		if ( isset( parse_url( $baseFile->getUrl() )['host'] ) ) {
+			$urls[] = $baseFile->getUrl();
+		} else {
+			$urls[] = sprintf(
+				'%s/%s',
+				$url,
+				ltrim( $baseFile->getUrl(), '/' )
+			);
+		}
+
+		return $urls;
+	}
+
+	/**
+	 * Purges an array of urls
+	 *
+	 * @param array $urls
+	 */
+	private function runPurge( array $urls ): void {
+		MediaWikiServices::getInstance()->getHtmlCacheUpdater()->purgeUrls( $urls );
+
+		( new HookUtils() )->purgeUrls( $urls );
+	}
+
+	/**
+	 * @param Article|WikiPage|Title $page
+	 * @return bool
+	 */
+	private function isValid( $page ): bool {
+		if ( $page instanceof Title ) {
+			return $page->getNamespace() === NS_FILE;
+		}
+
+		return $page instanceof WikiFilePage && $page->getTitle() !== null && $page->getTitle()->getNamespace() === NS_FILE;
 	}
 }


### PR DESCRIPTION
This 'hacks' the retrieval of image thumbnails.  
The access to `getThumbnails` is made public by reflecting the class, somewhat a violation of coding standards, but as the method is made public in the next release I think this is okay.